### PR TITLE
pingv2: prefer X-Forwarded-For over RemoteAddr

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -175,8 +175,12 @@ func submitv2(w http.ResponseWriter, r *http.Request) {
 	}
 	req.Header.Set("Referer", referer.String())
 	req.Header.Set("User-Agent", r.Header.Get("User-Agent"))
-	req.Header.Set(xForwardedForHeaderName, r.RemoteAddr)
-	req.RemoteAddr = r.RemoteAddr
+
+	remoteAddr := r.Header.Get(xForwardedForHeaderName)
+	if remoteAddr == "" {
+		remoteAddr = r.RemoteAddr
+	}
+	req.Header.Set(xForwardedForHeaderName, remoteAddr)
 
 	addCorsHeaders(w, r)
 


### PR DESCRIPTION
This fixes compatibility with reverse proxies like nginx that can set X-Forwarded-For.