### PR TITLE
Support Sec-GPC header

### DIFF
--- a/secgpc/secgpc.go
+++ b/secgpc/secgpc.go
@@ -1,0 +1,34 @@
+package secgpc
+
+import (
+	"net/http"
+)
+
+const SecGPCHeaderName = "Sec-GPC"
+const SecGPCHeaderValue = "1"
+
+func RequestsGlobalPrivacyControl(r *http.Request) bool {
+	return r.Header.Get(SecGPCHeaderName) == SecGPCHeaderValue
+}
+
+func SetGlobalPrivacyControl(w http.ResponseWriter) {
+	w.Header().Set(SecGPCHeaderName, SecGPCHeaderValue)
+}
+
+func NewMiddleware(nextHandler http.Handler) http.Handler {
+	return secgpcMiddleware{nextHandler: nextHandler}
+}
+
+type secgpcMiddleware struct {
+	nextHandler http.Handler
+}
+
+func (d secgpcMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if RequestsGlobalPrivacyControl(r) {
+		SetGlobalPrivacyControl(w)
+		// Note: All w.Header() modifications must be made BEFORE this call.
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	d.nextHandler.ServeHTTP(w, r)
+}

--- a/secgpc/secgpc_test.go
+++ b/secgpc/secgpc_test.go
@@ -1,0 +1,42 @@
+package secgpc
+
+import (
+	"net/http"
+	"net/textproto"
+	"testing"
+)
+
+func TestRequestsGlobalPrivacyControl(t *testing.T) {
+	// Header is set correctly. Do not track this request.
+	req := &http.Request{Header: http.Header(map[string][]string{
+		// We use Sec-Gpc here instead of Sec-GPC because of the way req.Header.Get
+		// works. It converts the input with CanonicalMIMEHeaderKey and
+		// checks the map for that value. When the request is built, the
+		// map is made by converting keys using this same method so the
+		// lookup is always seamless.
+		"Sec-Gpc": {SecGPCHeaderValue},
+	})}
+
+	if !RequestsGlobalPrivacyControl(req) {
+		t.Fatalf("expected Sec-GPC header to be respected, headers: %+v, %s header: %+v",
+			req.Header,
+			textproto.CanonicalMIMEHeaderKey(SecGPCHeaderName),
+			req.Header.Get(SecGPCHeaderName))
+	}
+
+	// Header is not set. We can track this request.
+	req = &http.Request{Header: map[string][]string{}}
+
+	if RequestsGlobalPrivacyControl(req) {
+		t.Fatalf("expected lack of Sec-GPC header to mean we can track")
+	}
+
+	// Header is not set correctly. We can track this request.
+	req = &http.Request{Header: map[string][]string{
+		"Sec-Gpc": {"!"},
+	}}
+
+	if RequestsGlobalPrivacyControl(req) {
+		t.Fatalf("expected value of Sec-GPC header to mean we can track")
+	}
+}


### PR DESCRIPTION
This replaces the DNT (Do Not Track) header.

https://globalprivacycontrol.org/

Fixes #76 